### PR TITLE
Fixed filename of footer-snippet

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -162,7 +162,7 @@ module.exports = function(grunt) {
     processhtml: {
       site: {
         files: {
-         'dist/site/snippets/page-footer.php': ['site/snippets/page-footer.php']
+         'dist/site/snippets/footer.php': ['site/snippets/footer.php']
         },
       },
     },


### PR DESCRIPTION
Wondered why livereload worked on the live site - thats why